### PR TITLE
Fixed B flag consistency, internally and on the stack. 

### DIFF
--- a/fake6502.c
+++ b/fake6502.c
@@ -588,7 +588,7 @@ void ply(context_t * c) {
 }
 
 void plp(context_t * c) {
-    c->flags = (pull8(c) | FLAG_CONSTANT) & ~FLAG_BREAK;
+    c->flags = pull8(c) | FLAG_CONSTANT | FLAG_BREAK;
 }
 
 void rol(context_t * c) {
@@ -615,7 +615,7 @@ void ror(context_t * c) {
 }
 
 void rti(context_t * c) {
-    c->flags = (pull8(c) | FLAG_CONSTANT) & ~FLAG_BREAK;
+    c->flags = pull8(c) | FLAG_CONSTANT | FLAG_BREAK;
     c->pc = pull16(c);
 }
 
@@ -846,7 +846,7 @@ static const uint8_t ticktable[256] = {
 
 void nmi6502(context_t * c) {
     push16(c, c->pc);
-    push8(c, c->flags);
+    push8(c, c->flags & ~FLAG_BREAK);
     c->flags |= FLAG_INTERRUPT;
     c->pc = (uint16_t)mem_read(c, 0xFFFA) | ((uint16_t)mem_read(c, 0xFFFB) << 8);
 }
@@ -858,7 +858,7 @@ uint16_t getPC(context_t * c) {
 void irq6502(context_t * c) {
     if((c->flags & FLAG_INTERRUPT) == 0) {
         push16(c, c->pc);
-        push8(c, c->flags);
+        push8(c, c->flags & ~FLAG_BREAK);
         c->flags |= FLAG_INTERRUPT;
         c->pc = (uint16_t)mem_read(c, 0xFFFE) | ((uint16_t)mem_read(c, 0xFFFF) << 8);
     }


### PR DESCRIPTION
Internal B flag is now always "set".