### PR TITLE
Fixed an issue in compare() + "original" reset vector handling.

### DIFF
--- a/fake6502.c
+++ b/fake6502.c
@@ -182,8 +182,8 @@ uint8_t pull8(context_t * c) {
 }
 
 void reset6502(context_t * c) {
-    // pc = ((uint16_t)mem_read(0xfffc) | ((uint16_t)mem_read(0xfffd) << 8));
-    c->pc = 0xff00;
+    c->pc = ((uint16_t)mem_read(c, 0xfffc) | ((uint16_t)mem_read(c, 0xfffd) << 8));
+    //c->pc = 0xff00;
 
     c->a = 0;
     c->x = 0;
@@ -415,9 +415,9 @@ void compare(context_t * c, uint16_t r) {
     uint16_t value = getvalue(c);
     uint16_t result = r - value;
    
-    if (c->a >= (uint8_t)(value & 0x00FF)) setcarry(c);
+    if (r >= (uint8_t)(value & 0x00FF)) setcarry(c);
         else clearcarry(c);
-    if (c->a == (uint8_t)(value & 0x00FF)) setzero(c);
+    if (r == (uint8_t)(value & 0x00FF)) setzero(c);
         else clearzero(c);
     signcalc(c, result);
 }


### PR DESCRIPTION
The change in reset6502() wasn't really intended to be committed yet (I wanted to check with you first), because I'm not sure if this is on purpose or not. The reading of the reset vector obviously was commented out for a reason...

For my "emulator" I need the official behaviour, so I changed it. (Thinking I would remember not to commit it yet, oh well...)
So if you need the "weird" reset vector for some reason, I wouldn't mind if you skip that part.
(Maybe I'm just completely ignorant about a 6502 variant that has 0xff00 as reset vector?)

The issue in the compare() function seems to be another artifact of refactoring.
It uses the accumulator, no matter which compare opcode was used (CMP, CPX, ..)
I replaced it with the parameter "r", which seems to be the intended value for comparison.

With these changes, C64 Basic gets finally booted up and running (into the "blinking cursor" loop...)

