### PR TITLE
Fixed missing update of Z-flag in and()

### DIFF
--- a/fake6502.c
+++ b/fake6502.c
@@ -319,6 +319,8 @@ void adc(context_t * c) {
 void and(context_t * c) {
     uint8_t m = getvalue(c);
     uint16_t result = (uint16_t)c->a & m;
+
+    zerocalc(c, result);
     signcalc(c, result);
    
     saveaccum(c, result);


### PR DESCRIPTION
The and() opcode seems to have lost its capability to talk to the Z-flag.
I propose to give that capability back. :smiley: