### PR TITLE
basic source code tidy up, step() -> step6502()

### DIFF
--- a/fake6502.c
+++ b/fake6502.c
@@ -31,7 +31,7 @@ address above so that I can fix it. Thank you!
 
 <hr width=50%>
 
-In Dec 2020, this folk was created by 'omarandlorraine':
+In Dec 2020, this fork was created by 'omarandlorraine':
 
 https://github.com/omarandlorraine/fake6502
 
@@ -45,7 +45,7 @@ Source code tidy up, for better inclusion as a source code library.
 
 v2.0 <br/>
 14 Dec 2020 <br/>
-First folk of project by
+First fork of project by
 <a href='https://github.com/omarandlorraine'> omarandlorraine</a>.
 
 - - -
@@ -151,7 +151,6 @@ ie. at the next call to step6502().
 
 #if 0
 #define NMOS6502
-#else
 #define CMOS6502
 #endif
 

--- a/fake6502.h
+++ b/fake6502.h
@@ -1,4 +1,14 @@
+
+#ifndef FAKE6502_H
+#define FAKE6502_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 #include <stdint.h>
+
 typedef struct c1 {
     uint8_t a;
     uint8_t x;
@@ -17,10 +27,17 @@ void push6502_16(context_t *c, uint16_t pushval);
 uint8_t pull6502_8(context_t *c);
 uint16_t pull6502_16(context_t *c);
 
-void step(context_t * c);
 void reset6502(context_t * c);
 void irq6502(context_t * c);
 void nmi6502(context_t * c);
+void step6502(context_t * c);
+
 uint8_t mem_read(context_t * c, uint16_t address);
 void mem_write(context_t * c, uint16_t address, uint8_t val);
 
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/tests.c
+++ b/tests.c
@@ -59,7 +59,7 @@ void exec_instruction(context_t *cpu, uint8_t opcode, uint8_t op1,
 
     cpu->clockticks = reads = writes = 0;
 
-    step(cpu);
+    step6502(cpu);
 }
 
 int interrupt() {


### PR DESCRIPTION
Only code change is renaming the function step() -> step6502(), to be inline with the other user functions.

Updated comments / header / documentation, and move it around a bit.

Moved function reset6502() to be with the other 'user' functions.

Put usual wrappers around the header file.
