### PR TITLE
Fix carry flag behavour for binary and decimal ADC/SBC

### DIFF
--- a/tests.c
+++ b/tests.c
@@ -266,6 +266,17 @@ int test_decimal_mode()
     CHECK(cpu.pc, 0x20a);
     CHECK(cpu.a, 0x88);
 
+    // Check carry flag
+    f6502.cpu.a = 0x99;
+    fake6502_carry_set(&f6502);
+    test_exec_instruction(&f6502, 0x69, 0x99, 0x00); // ADC #$99
+    CHECKFLAG(FAKE6502_CARRY_FLAG, 1);
+
+    f6502.cpu.a = 0x99;
+    fake6502_carry_set(&f6502);
+    test_exec_instruction(&f6502, 0xe9, 0x0, 0x00); // SBC #$99
+    CHECKFLAG(FAKE6502_CARRY_FLAG, 1);
+
     return(0);
 }
 
@@ -305,6 +316,10 @@ int test_binary_mode()
     test_exec_instruction(&f6502, 0xe9, 0x10, 0x00); // SBC #$10
     CHECK(cpu.pc, 0x20a);
     CHECK(cpu.a, 0x8c);
+
+    f6502.cpu.a = 0;
+    test_exec_instruction(&f6502, 0xe9, 0xff, 0x00); // SBC #$ff
+    CHECKFLAG(FAKE6502_CARRY_FLAG, 0);
 
     return(0);
 }


### PR DESCRIPTION
While running [Klaus2m5's functional tests](https://github.com/Klaus2m5/6502_65C02_functional_tests/) on a fake6502-based simulator, I found the following bugs:

### Failure in binary subtraction

```
lda #0
sbc $#ff
```

Expected result is `A=0`, `C=0` but it returns with the carry flag set.

The fix for this is to treat `SBC` as addition with a ones-complemented value. This more closely reflects what the original hardware is doing. 

The current version uses subtraction which causes the high byte of the result to be set to `0xff`. If you trace through SBC with this test case, you will see that the value passed to `fake6502_carry_calc` is `0xff00`, the result in the low byte is fine but as this value `> 0x00ff`, carry is incorrectly set.

### Failure in decimal addition

```
sed
sec
lda #$99
sbc #$99
```

Expected result is `A=0`, `C=1`, but it returns with the carry flag clear. Fix here is to apply [Mike B's BCD carry detection method](http://forum.6502.org/viewtopic.php?p=37758#p37758).

### Failure in decimal subtraction

```
sed
sec
lda #$99
sbc #0
```

Expected result is `A=0`, `C=1`, but it returns with the carry flag clear. Similar to the binary SBC bug, the fix here was to treat the operand as a nines-complement value which is then passed to `add8` rather than using subtraction. 

## What I've done

- Applied fixes as described above
- Tested on Klaus2m5's 6502 functional tests
- Added unit tests for binary/decimal carry behavour